### PR TITLE
feat(story): 스토리 v0.6 반영 – 전투 및 엔딩 흐름 추가

### DIFF
--- a/frontend/src/app/story/[chapterSlug]/[storySlug]/DetailClient.tsx
+++ b/frontend/src/app/story/[chapterSlug]/[storySlug]/DetailClient.tsx
@@ -13,8 +13,8 @@ import { SceneDisplay } from './components/SceneDisplay';
 import { QuestSelector } from './components/QuestSelector';
 import { BranchVoting } from './components/BranchVoting';
 import { VotingResult } from './components/VotingResult';
-import { toast } from 'sonner';
-import { useEffect } from 'react';
+import BattleHandler from './components/BattleHandler';
+import EndStoryButton from './components/EndStoryButton';
 
 const DetailClient = () => {
   const { storySlug, chapterSlug } = useParams();
@@ -43,19 +43,6 @@ const DetailClient = () => {
     sessionId: chapter?.id ?? 1,
     onVoteEnd: () => setIsSkipping(true),
   });
-
-  const errorToast = (err: string) => {
-    toast('Proposal 생성 오류', {
-      description: err,
-      id: 'proposal-error',
-    });
-  };
-
-  useEffect(() => {
-    if (proposalError) {
-      errorToast(proposalError);
-    }
-  }, [proposalError]);
 
   if (!story) {
     return (
@@ -110,6 +97,21 @@ const DetailClient = () => {
             chapterSlug={chapterSlug as string}
           />
         )}
+
+      {isSceneComplete &&
+        story?.quests?.length === 0 &&
+        !story?.BranchPoint?.[0] &&
+        storySlug != 'ancient-power-revealed' && (
+          <BattleHandler
+            isSceneComplete={isSceneComplete}
+            story={story}
+            chapterSlug={chapterSlug as string}
+          />
+        )}
+
+      {isSceneComplete && storySlug == 'ancient-power-revealed' && (
+        <EndStoryButton />
+      )}
     </div>
   );
 };

--- a/frontend/src/app/story/[chapterSlug]/[storySlug]/components/BattleHandler.tsx
+++ b/frontend/src/app/story/[chapterSlug]/[storySlug]/components/BattleHandler.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import BattleComponent from '@/app/components/battle/BattleComponent';
+
+interface BattleHandlerProps {
+  isSceneComplete: boolean;
+  story: {
+    quests?: any[];
+    BranchPoint?: any[];
+  };
+  chapterSlug: string;
+}
+
+const BattleHandler = ({
+  isSceneComplete,
+  story,
+  chapterSlug,
+}: BattleHandlerProps) => {
+  const [startBattle, setStartBattle] = useState(false);
+  const [battleEnded, setBattleEnded] = useState(false);
+  const [isVictory, setIsVictory] = useState(false);
+  const router = useRouter();
+
+  const shouldTriggerBattle =
+    isSceneComplete &&
+    (story?.quests?.length ?? 0) === 0 &&
+    !story?.BranchPoint?.[0];
+
+  if (!shouldTriggerBattle) return null;
+
+  return (
+    <div className="mt-8 flex flex-col items-center">
+      {!startBattle && !battleEnded && (
+        <button
+          onClick={() => setStartBattle(true)}
+          className="px-6 py-3 bg-red-700 text-white font-bold rounded-lg hover:bg-red-800 transition"
+        >
+          🐉 용과 싸우러 가기
+        </button>
+      )}
+
+      {startBattle && !battleEnded && (
+        <BattleComponent
+          speed={500}
+          onClose={(victory: boolean) => {
+            setBattleEnded(true);
+            setIsVictory(victory);
+          }}
+        />
+      )}
+
+      {battleEnded && (
+        <div className="mt-6 flex flex-col items-center gap-4">
+          {isVictory ? (
+            <button
+              className="bg-blue-600 text-white px-6 py-3 rounded-lg font-semibold hover:bg-blue-700"
+              onClick={() =>
+                router.push(`/story/${chapterSlug}/ancient-power-revealed`)
+              }
+            >
+              🎉 다음 이야기로 이동하기
+            </button>
+          ) : (
+            <button
+              className="bg-gray-800 text-white px-6 py-3 rounded-lg font-semibold hover:bg-gray-700"
+              onClick={() => {
+                setStartBattle(false);
+                setBattleEnded(false);
+                setIsVictory(false);
+              }}
+            >
+              💀 다시 도전하기
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default BattleHandler;

--- a/frontend/src/app/story/[chapterSlug]/[storySlug]/components/EndStoryButton.tsx
+++ b/frontend/src/app/story/[chapterSlug]/[storySlug]/components/EndStoryButton.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import React from 'react';
+import { useRouter } from 'next/navigation';
+
+const EndStoryButton = () => {
+  const router = useRouter();
+
+  const handleClick = () => {
+    console.log('📘 스토리 종료 처리!');
+    router.push('/story');
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      className="px-6 py-3 bg-gray-800 text-white font-bold rounded-lg hover:bg-gray-700 transition"
+    >
+      📘 스토리 종료하기
+    </button>
+  );
+};
+
+export default EndStoryButton;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -20,9 +20,7 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"],
-      "@/contracts/*": ["../blockchain/artifacts/contracts/dao.sol/*"],
-      "@/deployments/*": ["./deployments/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": [


### PR DESCRIPTION
- DetailClient에 스토리 전투 및 종료 흐름 조건부 렌더링 추가
- 퀘스트/분기점이 없고 씬 완료 시 BattleHandler 컴포넌트 출력
- BattleHandler 내에서 드래곤 전투 진행 (BattleComponent 사용)
  - 전투 승리 시 다음 스토리(slug: ancient-power-revealed)로 이동
  - 전투 패배 시 재도전 버튼 노출
- storySlug가 'ancient-power-revealed'일 경우 EndStoryButton 출력
  - 클릭 시 /story 페이지로 이동하며 스토리 종료 처리
- BattleHandler 및 EndStoryButton 컴포넌트로 분리하여 재사용성 확보